### PR TITLE
fix BCD mode handling

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,9 +1,9 @@
+use criterion::{criterion_group, criterion_main, Criterion};
 use emulator_6502::*;
 use std::env::var;
 use std::fs::*;
 use std::io::*;
 use std::path::PathBuf;
-use criterion::{criterion_group, criterion_main, Criterion};
 
 struct BasicRam {
     ram: Box<[u8; u16::max_value() as usize + 1]>,

--- a/src/opcodes/illegal.rs
+++ b/src/opcodes/illegal.rs
@@ -580,8 +580,9 @@ mod test {
             accumulator: 0x00,
             ..cpu_initial
         };
-        cpu_expected.set_flag(StatusFlag::Zero, true);
+        cpu_expected.set_flag(StatusFlag::Zero, false);
         cpu_expected.set_flag(StatusFlag::Carry, true);
+        cpu_expected.set_flag(StatusFlag::Negative, true);
 
         rra(&mut cpu_initial, &mut stub_bus, AddressModeValue::AbsoluteAddress(0x00ff));
 


### PR DESCRIPTION
While testing https://github.com/mrk-its/bevy-atari with `binary_coded_decimal` feature enabled I've found that BCD mode is not working properly (wrong score display in few games, also Atari Basic was unable to perform properly any arithmetic operation (it seems it uses heavily BCD mode in their floating point implementation). This PR fixes BCD mode implementation (I was using using http://www.6502.org/tutorials/decimal_mode.html as guide) and adds many tests covering it (mostly from http://visual6502.org/wiki/index.php?title=6502DecimalMode).

