### PR TITLE
Expose total cycle counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ struct BasicRam{
 
 impl BasicRam {
     fn load_program(&mut self, start: usize, data: &mut Vec<u8>){
-        self.ram[start..].clone_from_slice(data);
+        self.ram[start..(start + data.len())].clone_from_slice(data);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,6 +391,11 @@ impl MOS6502 {
         self.status_register = 0x34;
         self.remaining_cycles = 8;
     }
+
+    /// Returns the total number of cycles executed. Not affected by the reset method.
+    pub fn get_total_cycles(&self) -> u64 {
+        self.total_cycles
+    }
 }
 
 /// Wrapper function for reading 16 bits at a time

--- a/src/opcodes/mod.rs
+++ b/src/opcodes/mod.rs
@@ -59,7 +59,7 @@ pub(super) static OPCODE_TABLE: [Instruction; 256] = [
         name: "kil",
         function: kil,
         address_mode: implied,
-        cycles: 0,
+        cycles: 2,
     }, //0x2
     Instruction {
         name: "slo",
@@ -155,7 +155,7 @@ pub(super) static OPCODE_TABLE: [Instruction; 256] = [
         name: "kil",
         function: kil,
         address_mode: implied,
-        cycles: 0,
+        cycles: 2,
     }, //0x12
     Instruction {
         name: "slo",
@@ -251,7 +251,7 @@ pub(super) static OPCODE_TABLE: [Instruction; 256] = [
         name: "kil",
         function: kil,
         address_mode: implied,
-        cycles: 0,
+        cycles: 2,
     }, //0x22
     Instruction {
         name: "rla",
@@ -347,7 +347,7 @@ pub(super) static OPCODE_TABLE: [Instruction; 256] = [
         name: "kil",
         function: kil,
         address_mode: implied,
-        cycles: 0,
+        cycles: 2,
     }, //0x32
     Instruction {
         name: "rla",
@@ -443,7 +443,7 @@ pub(super) static OPCODE_TABLE: [Instruction; 256] = [
         name: "kil",
         function: kil,
         address_mode: implied,
-        cycles: 0,
+        cycles: 2,
     }, //0x42
     Instruction {
         name: "sre",
@@ -539,7 +539,7 @@ pub(super) static OPCODE_TABLE: [Instruction; 256] = [
         name: "kil",
         function: kil,
         address_mode: implied,
-        cycles: 0,
+        cycles: 2,
     }, //0x52
     Instruction {
         name: "sre",
@@ -635,7 +635,7 @@ pub(super) static OPCODE_TABLE: [Instruction; 256] = [
         name: "kil",
         function: kil,
         address_mode: implied,
-        cycles: 0,
+        cycles: 2,
     }, //0x62
     Instruction {
         name: "rra",
@@ -731,7 +731,7 @@ pub(super) static OPCODE_TABLE: [Instruction; 256] = [
         name: "kil",
         function: kil,
         address_mode: implied,
-        cycles: 0,
+        cycles: 2,
     }, //0x72
     Instruction {
         name: "rra",
@@ -923,7 +923,7 @@ pub(super) static OPCODE_TABLE: [Instruction; 256] = [
         name: "kil",
         function: kil,
         address_mode: implied,
-        cycles: 0,
+        cycles: 2,
     }, //0x92
     Instruction {
         name: "ahx",
@@ -1115,7 +1115,7 @@ pub(super) static OPCODE_TABLE: [Instruction; 256] = [
         name: "kil",
         function: kil,
         address_mode: implied,
-        cycles: 0,
+        cycles: 2,
     }, //0xb2
     Instruction {
         name: "lax",
@@ -1307,7 +1307,7 @@ pub(super) static OPCODE_TABLE: [Instruction; 256] = [
         name: "kil",
         function: kil,
         address_mode: implied,
-        cycles: 0,
+        cycles: 2,
     }, //0xd2
     Instruction {
         name: "dcp",
@@ -1499,7 +1499,7 @@ pub(super) static OPCODE_TABLE: [Instruction; 256] = [
         name: "kil",
         function: kil,
         address_mode: implied,
-        cycles: 0,
+        cycles: 2,
     }, //0xf2
     Instruction {
         name: "isc",


### PR DESCRIPTION
For benchmarking purposes, it's nice to know how long something takes to execute, and a field that counts the total number of cycles since the MOS6502 instance was created already existed, so I just exposed it. In the process, I noticed that the cycles per instruction ratio (when executing random instructions from a randomly initialised RAM) was surprisingly high and found that the KIL instruction was underflowing the cycle counter, resulting in 255 cycles being attributed to it. I think pretending that it's just a NOP makes the most sense. My fuzzing (which I wanted to use to test how good the performance of the emulator is) also showed various other overflows and underflows, seemingly regarding cases such as `ldx #1 lda $FFFF, X`, but that's a topic for another pull request :)
Here's my (admittedly ugly) fuzzing/"benchmarking" program: https://pastebin.com/nff8Q5Kv